### PR TITLE
handle timestamp as date

### DIFF
--- a/src/utils/getFieldDate/getFieldDate.test.ts
+++ b/src/utils/getFieldDate/getFieldDate.test.ts
@@ -36,6 +36,6 @@ describe('getFieldDate', () => {
 
     expect(getFieldDate('1699597055066')).toEqual(
       new Date('2023-11-10T06:17:35.066Z')
-    )
+    );
   });
 });

--- a/src/utils/getFieldDate/getFieldDate.test.ts
+++ b/src/utils/getFieldDate/getFieldDate.test.ts
@@ -33,5 +33,9 @@ describe('getFieldDate', () => {
     expect(getFieldDate('2023-10-04T02:52:12.358Z')).toEqual(
       new Date('2023-10-04T02:52:12.358Z')
     );
+
+    expect(getFieldDate('1699597055066')).toEqual(
+      new Date('2023-11-10T06:17:35.066Z')
+    )
   });
 });

--- a/src/utils/getFieldDate/getFieldDate.ts
+++ b/src/utils/getFieldDate/getFieldDate.ts
@@ -45,7 +45,7 @@ export function getFieldDate(value: string) {
 
   // Timestamp ([0-9])
   if (/^\d+$/.test(value)) {
-    return new Date(+value)
+    return new Date(+value);
   }
 
   // Otherwise

--- a/src/utils/getFieldDate/getFieldDate.ts
+++ b/src/utils/getFieldDate/getFieldDate.ts
@@ -43,6 +43,11 @@ export function getFieldDate(value: string) {
     return new Date(`1970-01-01T${value}.000Z`);
   }
 
+  // Timestamp ([0-9])
+  if (/^\d+$/.test(value)) {
+    return new Date(+value)
+  }
+
   // Otherwise
   return new Date(value);
 }


### PR DESCRIPTION
closes #6

handles the case where a user uses a fn like `new Date().getTime()` as opposed to `new Date()` or `new Date().toISOString()`.