### PR TITLE
Fix undefined parse README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ async function server(formData: FormData) {
     });
 
     // Parse form values
-    const productData = parse(ProductSchema, formValues);
+    const productData = v.parse(ProductSchema, formValues);
 
     // Handle errors
   } catch (error) {


### PR DESCRIPTION
I copied and pasted the example and was wondering where parse() should come from. 