### PR TITLE
feat: support bracket notation for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add support for array bracket notation (pull request #15)
+
 ## v0.7.5 (June 01, 2024)
 
 - Republish previous version because build step was forgotten

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ import { decode } from 'https://deno.land/x/decode_formdata/mod.ts';
 
 `FormData` stores the names of your fields and their values. However, there is a problem. Only strings and files are accepted as values, but complex forms can contain booleans, strings and dates. This leads to the fact that the boolean value `true` must be mapped with `"on"` and `false` values are simply ignored. Numbers and dates are also converted to strings.
 
-Another problem are objects and arrays, which are usually mapped using dot notation. For example, the input field `<input name="todos.0.label" />` should map to the object `{ todos: [{ label: "" }] }`. By telling `decode` where arrays, booleans, dates, files, and numbers are located, the function can decode your `FormData` back into a complex JavaScript object.
+Another problem are objects and arrays, which are usually mapped using dot and bracket notation. For example, the input field `<input name="todos.0.label" />` should map to the object `{ todos: [{ label: "" }] }`. By telling `decode` where arrays, booleans, dates, files, and numbers are located, the function can decode your `FormData` back into a complex JavaScript object.
+
+> Both dot and bracket notation are supported for arrays.
 
 Consider the following form to add a new product to an online store:
 
@@ -46,17 +48,17 @@ Consider the following form to add a new product to an online store:
   <input name="active" type="checkbox" />
 
   <!-- Tags -->
-  <input name="tags[0]" type="text" />
-  <input name="tags[1]" type="text" />
-  <input name="tags[2]" type="text" />
+  <input name="tags.0" type="text" />
+  <input name="tags.1" type="text" />
+  <input name="tags.2" type="text" />
 
   <!-- Images -->
-  <input name="images[0].title" type="text" />
-  <input name="images[0].created" type="date" />
-  <input name="images[0].file" type="file" />
-  <input name="images[1].title" type="text" />
-  <input name="images[1].created" type="date" />
-  <input name="images[1].file" type="file" />
+  <input name="images.0.title" type="text" />
+  <input name="images.0.created" type="date" />
+  <input name="images.0.file" type="file" />
+  <input name="images.1.title" type="text" />
+  <input name="images.1.created" type="date" />
+  <input name="images.1.file" type="file" />
 </form>
 ```
 
@@ -68,15 +70,15 @@ const formEntries = [
   ['price', '0.89'],
   ['created', '2023-10-09'],
   ['active', 'on'],
-  ['tags[0]', 'fruit'],
-  ['tags[1]', 'healthy'],
-  ['tags[2]', 'sweet'],
-  ['images[0].title', 'Close up of an apple'],
-  ['images[0].created', '2023-08-24'],
-  ['images[0].file', Blob],
-  ['images[1].title', 'Our fruit fields at Lake Constance'],
-  ['images[1].created', '2023-08-12'],
-  ['images[1].file', Blob],
+  ['tags.0', 'fruit'],
+  ['tags.1', 'healthy'],
+  ['tags.2', 'sweet'],
+  ['images.0.title', 'Close up of an apple'],
+  ['images.0.created', '2023-08-24'],
+  ['images.0.file', Blob],
+  ['images.1.title', 'Our fruit fields at Lake Constance'],
+  ['images.1.created', '2023-08-12'],
+  ['images.1.file', Blob],
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Consider the following form to add a new product to an online store:
   <input name="active" type="checkbox" />
 
   <!-- Tags -->
-  <input name="tags.0" type="text" />
-  <input name="tags.1" type="text" />
-  <input name="tags.2" type="text" />
+  <input name="tags[0]" type="text" />
+  <input name="tags[1]" type="text" />
+  <input name="tags[2]" type="text" />
 
   <!-- Images -->
-  <input name="images.0.title" type="text" />
-  <input name="images.0.created" type="date" />
-  <input name="images.0.file" type="file" />
-  <input name="images.1.title" type="text" />
-  <input name="images.1.created" type="date" />
-  <input name="images.1.file" type="file" />
+  <input name="images[0].title" type="text" />
+  <input name="images[0].created" type="date" />
+  <input name="images[0].file" type="file" />
+  <input name="images[1].title" type="text" />
+  <input name="images[1].created" type="date" />
+  <input name="images[1].file" type="file" />
 </form>
 ```
 
@@ -68,15 +68,15 @@ const formEntries = [
   ['price', '0.89'],
   ['created', '2023-10-09'],
   ['active', 'on'],
-  ['tags.0', 'fruit'],
-  ['tags.1', 'healthy'],
-  ['tags.2', 'sweet'],
-  ['images.0.title', 'Close up of an apple'],
-  ['images.0.created', '2023-08-24'],
-  ['images.0.file', Blob],
-  ['images.1.title', 'Our fruit fields at Lake Constance'],
-  ['images.1.created', '2023-08-12'],
-  ['images.1.file', Blob],
+  ['tags[0]', 'fruit'],
+  ['tags[1]', 'healthy'],
+  ['tags[2]', 'sweet'],
+  ['images[0].title', 'Close up of an apple'],
+  ['images[0].created', '2023-08-24'],
+  ['images[0].file', Blob],
+  ['images[1].title', 'Our fruit fields at Lake Constance'],
+  ['images[1].created', '2023-08-12'],
+  ['images[1].file', Blob],
 ];
 ```
 
@@ -174,3 +174,7 @@ Find a bug or have an idea how to improve the library? Please fill out an [issue
 ## License
 
 This project is available free of charge and licensed under the [MIT license](https://github.com/fabian-hiller/decode-formdata/blob/main/LICENSE.md).
+
+## Note
+
+Both dot and bracket notation are supported for arrays.

--- a/src/decode.test.ts
+++ b/src/decode.test.ts
@@ -74,6 +74,16 @@ describe('decode', () => {
     });
   });
 
+  test('should decode indexed arrays with bracket notation', () => {
+    const formData = new FormData();
+    formData.append('array[0]', 'index_0');
+    formData.append('array[1]', 'index_1');
+    formData.append('array[2]', 'index_2');
+    expect(decode(formData, { arrays: ['array'] })).toEqual({
+      array: ['index_0', 'index_1', 'index_2'],
+    });
+  });
+
   test('should decode non-indexed arrays', () => {
     const formData = new FormData();
     formData.append('array', 'index_0');
@@ -100,6 +110,18 @@ describe('decode', () => {
     });
   });
 
+  test('should decode numbers in array with bracket notation', () => {
+    const formData = new FormData();
+    formData.append('array[0]', '111');
+    formData.append('array[1]', '222');
+    formData.append('array[2]', '333');
+    expect(
+      decode(formData, { arrays: ['array'], numbers: ['array.$'] })
+    ).toEqual({
+      array: [111, 222, 333],
+    });
+  });
+
   test('should decode objects', () => {
     const formData = new FormData();
     formData.append('nested.string', 'hello');
@@ -113,6 +135,21 @@ describe('decode', () => {
     formData.append('nested.0.array.0', 'index_0');
     formData.append('nested.0.array.1', 'index_1');
     formData.append('nested.0.array.2', 'index_2');
+    expect(
+      decode(formData, {
+        arrays: ['nested.$.array', 'empty.array'],
+      })
+    ).toEqual({
+      nested: [{ array: ['index_0', 'index_1', 'index_2'] }],
+      empty: { array: [] },
+    });
+  });
+
+  test('should decode nested arrays with bracket notation', () => {
+    const formData = new FormData();
+    formData.append('nested[0].array[0]', 'index_0');
+    formData.append('nested[0].array[1]', 'index_1');
+    formData.append('nested[0].array[2]', 'index_2');
     expect(
       decode(formData, {
         arrays: ['nested.$.array', 'empty.array'],

--- a/src/decode.test.ts
+++ b/src/decode.test.ts
@@ -64,7 +64,7 @@ describe('decode', () => {
     expect(decode(formData, { files: ['file'] })).toEqual({ file });
   });
 
-  test('should decode indexed arrays', () => {
+  test('should decode indexed arrays with dot notation', () => {
     const formData = new FormData();
     formData.append('array.0', 'index_0');
     formData.append('array.1', 'index_1');
@@ -98,7 +98,7 @@ describe('decode', () => {
     });
   });
 
-  test('should decode numbers in array', () => {
+  test('should decode numbers in array with dot notation', () => {
     const formData = new FormData();
     formData.append('array.0', '111');
     formData.append('array.1', '222');
@@ -116,7 +116,7 @@ describe('decode', () => {
     formData.append('array[1]', '222');
     formData.append('array[2]', '333');
     expect(
-      decode(formData, { arrays: ['array'], numbers: ['array.$'] })
+      decode(formData, { arrays: ['array'], numbers: ['array[$]'] })
     ).toEqual({
       array: [111, 222, 333],
     });
@@ -130,7 +130,7 @@ describe('decode', () => {
     });
   });
 
-  test('should decode nested arrays', () => {
+  test('should decode nested arrays with dot notation', () => {
     const formData = new FormData();
     formData.append('nested.0.array.0', 'index_0');
     formData.append('nested.0.array.1', 'index_1');
@@ -152,7 +152,7 @@ describe('decode', () => {
     formData.append('nested[0].array[2]', 'index_2');
     expect(
       decode(formData, {
-        arrays: ['nested.$.array', 'empty.array'],
+        arrays: ['nested[$].array', 'empty.array'],
       })
     ).toEqual({
       nested: [{ array: ['index_0', 'index_1', 'index_2'] }],


### PR DESCRIPTION
This PR resolves #14

I just launched Copilot Workspace and tweaked the output a bit, if this PR doesn't make any sense feel free to discard it but... tests are passing :D

---

Add support for bracket notation for arrays in form data decoding.

* **README.md**
  - Update examples to include bracket notation for arrays.
  - Add a note explaining that both dot and bracket notation are supported.

* **src/decode.test.ts**
  - Add tests for decoding arrays using bracket notation.
  - Ensure existing tests for dot notation are not affected.

* **src/decode.ts**
  - Update the `decode` function to handle bracket notation for arrays.
  - Modify the logic to parse and decode form data entries with bracket notation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fabian-hiller/decode-formdata?shareId=26271277-0122-45ad-b47c-f7273595cfd5).